### PR TITLE
updated key add method and changed sources to get from https

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,11 @@ fi
 /usr/bin/env python3 -V >/dev/null || die "Please install 'python3'";
 
 # Install all dependencies:
-apt-key adv -qq --keyserver pool.sks-keyservers.net --recv-keys ED444FF07D8D0BF6 || apt-key adv -qq --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys ED444FF07D8D0BF6 || die "This may be a server issue. Please try again later";
-apt-get -qq -y -m install python3-apt || die;
+#apt-key adv -qq --keyserver pool.sks-keyservers.net --recv-keys ED444FF07D8D0BF6 || apt-key adv -qq --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys ED444FF07D8D0BF6 || die "This may be a server issue. Please try again later";
+#apt-get -qq -y -m install python3-apt || die;
+
+#new key adding
+wget -q -O - https://archive.kali.org/archive-key.asc | apt-key add -
 
 install -T -g root -o root -m 555 ./katoolin3.py "$DIR/$PROGRAM" || die;
 

--- a/katoolin3.py
+++ b/katoolin3.py
@@ -655,11 +655,12 @@ class APTManager:
         try:
             with open(self.sources_file, "w") as file:
                 file.write("# This file was automatically created by katoolin3. DO NOT MODIFY\n")
-                file.write("deb {} http://http.kali.org/kali kali-rolling main contrib non-free\n".format(arch))
+                file.write("deb {} https://http.kali.org/kali kali-rolling main contrib non-free\n".format(arch))
         except OSError as e:
             raise VisibleError() from e
 
         self.update()
+
         return self
 
     def __exit__(self, *nil):


### PR DESCRIPTION
The key pool server is not working so changed it to the direct apt-key add - downloaded from https://archive.kali.org/archive-key.asc.

Getting from HTTP is also not working--changed it to https.
